### PR TITLE
Hide terminal instead of killing it

### DIFF
--- a/terminal.sh
+++ b/terminal.sh
@@ -6,33 +6,51 @@
  width_screen=$(xrandr --current | grep '*' | uniq | awk '{print $1}' | cut -d 'x' -f1)
  height=180 #in pixels, height of the terminal
  delay_dd=0.001 #delay for the dropdown expand and hide, small is fast
- step=7 #step for the dropdown expand and hide
+ scroll_speed=7 #step for the dropdown expand and hide
 #substract 10px
 
 Current_dir=$(pwd) #I was trying to open the terminal in the working directory, but i failed. It's opening always in the $USER
 width_screen=$((width_screen-10))#i substracted 10px because it was bigger than my screen
 
-if test $(wmctrl -l | grep "DropDownTx7683" | wc -l) -ne 0
-#We test to see if there is a window opened with the name "DropDownTx7683"
-then
-  #The window already exists, so we close it. Also killing the process
-  win_id=$(wmctrl -l | grep "DropDownTx7683" | awk '{print $1}')
-  #Here we get the PID of the process, so we can kill it
-  win_pid=$(xprop -id $win_id | grep "PID" |awk '/PID/ {print $3}')
-  #Begin the hide process
-  for((c=$height; c>=0; c=c-$step))
+scroll_window() {
+  if test $1 -eq 0
+  then
+    local start=$height
+    local step=$((-1*$scroll_speed))
+    local stop=0
+  else
+    local start=0
+    local step=$scroll_speed
+    local stop=$height
+  fi
+  for c in $(seq $start $step $stop)
   do
-    #We are reducing the height of the terminal step by step
     $(wmctrl -r "DropDownTX7683" -e 0,0,-25,$width_screen,$c) #resize and position the box: maxWidth X 180 , position: top left
     #I added -25 at left position, so it won't show the title panel, if you have another suggestion please tell me
     #Because i searched alot and i could't find something to hide that toolbar
     sleep $delay_dd
   done
-  #End hide
-  kill $win_pid #kill the process
+}
+
+if test $(wmctrl -l | grep "DropDownTx7683" | wc -l) -ne 0
+#We test to see if there is a window opened with the name "DropDownTx7683"
+then
+  #The window already exists, so test if it's hidden or not
+  win_id=$(wmctrl -l | grep "DropDownTx7683" | awk '{print $1}')
+  if xprop -id $win_id | grep "_NET_WM_STATE_ABOVE"
+  #If the window has the above property, then we scroll it up and hide it. If not then we show it and scroll it down
+  then
+    scroll_window 0
+    $(wmctrl -r "DropDownTx7683" -b remove,above)
+    $(wmctrl -r "DropDownTx7683" -b add,hidden)
+  else
+    $(wmctrl -r "DropDownTx7683" -b remove,hidden)
+    $(wmctrl -r "DropDownTx7683" -b add,above)
+    scroll_window 1
+  fi
 else
   #There is no window named "DropDownTx" opened, so we will open one
-	$(xterm -bg "#161616" -geometry 200x1+0+-65 -fa "Monospace Bold" -fg green -fs 9  -name "DropDownTx7683" -xrm 'XTerm.vt100.allowTitleOps: false' -title "DropDownTx7683" -e "cd $Current_dir && /bin/bash") &
+  $(xterm -bg "#161616" -geometry 200x1+0+-65 -fa "Monospace Bold" -fg green -fs 9  -name "DropDownTx7683" -xrm 'XTerm.vt100.allowTitleOps: false' -title "DropDownTx7683" -e "cd $Current_dir && /bin/bash") &
   #XTerm fields:
     #-bg color -> Color of the background of the terminal. Can be also names, ex: -bg red, -bg "#ffffff"
     #-geometry ColumnsxLines+top+left -> columns and lines is in number of chars(used for the size of the window),I added -65 so it won't be vissible on the screen when it's opened
@@ -55,17 +73,11 @@ else
     sleep $delay_dd
   done
 
-	$(wmctrl -r "DropDownTx7683" -b add,sticky) #I don't know what this does, but it sounds like it will always stay on top, like above
-	$(wmctrl -r "DropDownTx7683" -b add,maximized_horz) #maximum width
-	$(wmctrl -r "DropDownTx7683" -b add,skip_pager,skip_taskbar) #doesn't show in the panel: window list
-	$(wmctrl -r "DropDownTx7683" -b add,above) #force it to stay above all windows
-	#Begin expand
-  for((c=0; c<=$height; c=c+$step))
-  do
-    $(wmctrl -r "DropDownTx7683" -e 0,0,-25,$width_screen,$c) #resize and position the box: maxWidth X 180 , position: top left
-    sleep $delay_dd
-  done
-  #End expand
-	$(wmctrl -r "DropDownTx7683" -e 0,0,-25,$width_screen,$height) #resize and position the box: maxWidth X 180 , position: top left
+  $(wmctrl -r "DropDownTx7683" -b add,sticky) #I don't know what this does, but it sounds like it will always stay on top, like above
+  $(wmctrl -r "DropDownTx7683" -b add,maximized_horz) #maximum width
+  $(wmctrl -r "DropDownTx7683" -b add,skip_pager,skip_taskbar) #doesn't show in the panel: window list
+  $(wmctrl -r "DropDownTx7683" -b add,above) #force it to stay above all windows
+  scroll_window 1
+  # $(wmctrl -r "DropDownTx7683" -e 0,0,-25,$width_screen,$height) #resize and position the box: maxWidth X 180 , position: top left
 fi
 exit 0

--- a/terminal.sh
+++ b/terminal.sh
@@ -47,6 +47,7 @@ then
     $(wmctrl -r "DropDownTx7683" -b remove,hidden)
     $(wmctrl -r "DropDownTx7683" -b add,above)
     scroll_window 1
+    $(wmctrl -a "DropDownTx7683")
   fi
 else
   #There is no window named "DropDownTx" opened, so we will open one


### PR DESCRIPTION
A drop-down style terminal is supposed to retain the information that was there before, not clear it every single time.

Also the script itself should be executable from the get-go.